### PR TITLE
Add redirects for oneCCL

### DIFF
--- a/oneccl/api/class_view_hierarchy.html
+++ b/oneccl/api/class_view_hierarchy.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/class_view_hierarchy.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/class_view_hierarchy.html
+---
+

--- a/oneccl/api/classccl_1_1ccl__error.html
+++ b/oneccl/api/classccl_1_1ccl__error.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/classccl_1_1ccl__error.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/classccl_1_1ccl__error.html
+---
+

--- a/oneccl/api/classccl_1_1communicator.html
+++ b/oneccl/api/classccl_1_1communicator.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/classccl_1_1communicator.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/classccl_1_1communicator.html
+---
+

--- a/oneccl/api/classccl_1_1environment.html
+++ b/oneccl/api/classccl_1_1environment.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/classccl_1_1environment.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/classccl_1_1environment.html
+---
+

--- a/oneccl/api/classccl_1_1request.html
+++ b/oneccl/api/classccl_1_1request.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/classccl_1_1request.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/classccl_1_1request.html
+---
+

--- a/oneccl/api/classccl_1_1stream.html
+++ b/oneccl/api/classccl_1_1stream.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/classccl_1_1stream.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/classccl_1_1stream.html
+---
+

--- a/oneccl/api/dir_include.html
+++ b/oneccl/api/dir_include.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/dir_include.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/dir_include.html
+---
+

--- a/oneccl/api/enum_ccl__types_8h_1a42085859d35d75cc288367198c003e0d.html
+++ b/oneccl/api/enum_ccl__types_8h_1a42085859d35d75cc288367198c003e0d.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/enum_ccl__types_8h_1a42085859d35d75cc288367198c003e0d.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/enum_ccl__types_8h_1a42085859d35d75cc288367198c003e0d.html
+---
+

--- a/oneccl/api/enum_ccl__types_8h_1a5872dcb7cc3a72fbf94a20d07ce6d63b.html
+++ b/oneccl/api/enum_ccl__types_8h_1a5872dcb7cc3a72fbf94a20d07ce6d63b.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/enum_ccl__types_8h_1a5872dcb7cc3a72fbf94a20d07ce6d63b.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/enum_ccl__types_8h_1a5872dcb7cc3a72fbf94a20d07ce6d63b.html
+---
+

--- a/oneccl/api/enum_ccl__types_8h_1a6f190c608822e4b3feff0e9c709fcc63.html
+++ b/oneccl/api/enum_ccl__types_8h_1a6f190c608822e4b3feff0e9c709fcc63.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/enum_ccl__types_8h_1a6f190c608822e4b3feff0e9c709fcc63.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/enum_ccl__types_8h_1a6f190c608822e4b3feff0e9c709fcc63.html
+---
+

--- a/oneccl/api/enum_ccl__types_8h_1a8753f2a133dd18aad81ee86a86f1cc90.html
+++ b/oneccl/api/enum_ccl__types_8h_1a8753f2a133dd18aad81ee86a86f1cc90.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/enum_ccl__types_8h_1a8753f2a133dd18aad81ee86a86f1cc90.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/enum_ccl__types_8h_1a8753f2a133dd18aad81ee86a86f1cc90.html
+---
+

--- a/oneccl/api/enum_ccl__types_8h_1af3d8cd4cfec3b312026597a874406e12.html
+++ b/oneccl/api/enum_ccl__types_8h_1af3d8cd4cfec3b312026597a874406e12.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/enum_ccl__types_8h_1af3d8cd4cfec3b312026597a874406e12.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/enum_ccl__types_8h_1af3d8cd4cfec3b312026597a874406e12.html
+---
+

--- a/oneccl/api/enum_ccl__types_8hpp_1a0cc079933a87903893e2bd84836cdbd6.html
+++ b/oneccl/api/enum_ccl__types_8hpp_1a0cc079933a87903893e2bd84836cdbd6.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/enum_ccl__types_8hpp_1a0cc079933a87903893e2bd84836cdbd6.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/enum_ccl__types_8hpp_1a0cc079933a87903893e2bd84836cdbd6.html
+---
+

--- a/oneccl/api/enum_ccl__types_8hpp_1a9b2e2854ccf9d79a41e4473ce4dc30a6.html
+++ b/oneccl/api/enum_ccl__types_8hpp_1a9b2e2854ccf9d79a41e4473ce4dc30a6.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/enum_ccl__types_8hpp_1a9b2e2854ccf9d79a41e4473ce4dc30a6.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/enum_ccl__types_8hpp_1a9b2e2854ccf9d79a41e4473ce4dc30a6.html
+---
+

--- a/oneccl/api/enum_ccl__types_8hpp_1ab82e3278c54a74e2560a3a5d198db300.html
+++ b/oneccl/api/enum_ccl__types_8hpp_1ab82e3278c54a74e2560a3a5d198db300.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/enum_ccl__types_8hpp_1ab82e3278c54a74e2560a3a5d198db300.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/enum_ccl__types_8hpp_1ab82e3278c54a74e2560a3a5d198db300.html
+---
+

--- a/oneccl/api/file_include_ccl.h.html
+++ b/oneccl/api/file_include_ccl.h.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/file_include_ccl.h.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/file_include_ccl.h.html
+---
+

--- a/oneccl/api/file_include_ccl.hpp.html
+++ b/oneccl/api/file_include_ccl.hpp.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/file_include_ccl.hpp.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/file_include_ccl.hpp.html
+---
+

--- a/oneccl/api/file_include_ccl_type_traits.hpp.html
+++ b/oneccl/api/file_include_ccl_type_traits.hpp.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/file_include_ccl_type_traits.hpp.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/file_include_ccl_type_traits.hpp.html
+---
+

--- a/oneccl/api/file_include_ccl_types.h.html
+++ b/oneccl/api/file_include_ccl_types.h.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/file_include_ccl_types.h.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/file_include_ccl_types.h.html
+---
+

--- a/oneccl/api/file_include_ccl_types.hpp.html
+++ b/oneccl/api/file_include_ccl_types.hpp.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/file_include_ccl_types.hpp.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/file_include_ccl_types.hpp.html
+---
+

--- a/oneccl/api/file_view_hierarchy.html
+++ b/oneccl/api/file_view_hierarchy.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/file_view_hierarchy.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/file_view_hierarchy.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a04a33f2c4525349680073a4a3c3d6a2f.html
+++ b/oneccl/api/function_ccl_8h_1a04a33f2c4525349680073a4a3c3d6a2f.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a04a33f2c4525349680073a4a3c3d6a2f.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a04a33f2c4525349680073a4a3c3d6a2f.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a171f3d1bc4ea2f1219fcd084c21587b6.html
+++ b/oneccl/api/function_ccl_8h_1a171f3d1bc4ea2f1219fcd084c21587b6.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a171f3d1bc4ea2f1219fcd084c21587b6.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a171f3d1bc4ea2f1219fcd084c21587b6.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a1cdf74249061dbabd47ea293832e9296.html
+++ b/oneccl/api/function_ccl_8h_1a1cdf74249061dbabd47ea293832e9296.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a1cdf74249061dbabd47ea293832e9296.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a1cdf74249061dbabd47ea293832e9296.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a2f90c583079ea7cc752e0323c1a6da14.html
+++ b/oneccl/api/function_ccl_8h_1a2f90c583079ea7cc752e0323c1a6da14.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a2f90c583079ea7cc752e0323c1a6da14.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a2f90c583079ea7cc752e0323c1a6da14.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a338cc1918d32ec4079f1777b67fc91fc.html
+++ b/oneccl/api/function_ccl_8h_1a338cc1918d32ec4079f1777b67fc91fc.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a338cc1918d32ec4079f1777b67fc91fc.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a338cc1918d32ec4079f1777b67fc91fc.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a3dd7671f84f0e6feefb0070ed716d3e9.html
+++ b/oneccl/api/function_ccl_8h_1a3dd7671f84f0e6feefb0070ed716d3e9.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a3dd7671f84f0e6feefb0070ed716d3e9.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a3dd7671f84f0e6feefb0070ed716d3e9.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a4a3092281bb0486bd832f9b3a48c1953.html
+++ b/oneccl/api/function_ccl_8h_1a4a3092281bb0486bd832f9b3a48c1953.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a4a3092281bb0486bd832f9b3a48c1953.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a4a3092281bb0486bd832f9b3a48c1953.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a4b7988205b012b6d5be39b7f865e79ec.html
+++ b/oneccl/api/function_ccl_8h_1a4b7988205b012b6d5be39b7f865e79ec.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a4b7988205b012b6d5be39b7f865e79ec.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a4b7988205b012b6d5be39b7f865e79ec.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a4c39317f260e16a8011a721aabd08169.html
+++ b/oneccl/api/function_ccl_8h_1a4c39317f260e16a8011a721aabd08169.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a4c39317f260e16a8011a721aabd08169.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a4c39317f260e16a8011a721aabd08169.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a89ca04757f4de077905961e506dfe534.html
+++ b/oneccl/api/function_ccl_8h_1a89ca04757f4de077905961e506dfe534.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a89ca04757f4de077905961e506dfe534.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a89ca04757f4de077905961e506dfe534.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a976c31a7b1a91c33b6a9c09f13cd1796.html
+++ b/oneccl/api/function_ccl_8h_1a976c31a7b1a91c33b6a9c09f13cd1796.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a976c31a7b1a91c33b6a9c09f13cd1796.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a976c31a7b1a91c33b6a9c09f13cd1796.html
+---
+

--- a/oneccl/api/function_ccl_8h_1a9e104eaa3dc77cb6d61030778637ed5a.html
+++ b/oneccl/api/function_ccl_8h_1a9e104eaa3dc77cb6d61030778637ed5a.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1a9e104eaa3dc77cb6d61030778637ed5a.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1a9e104eaa3dc77cb6d61030778637ed5a.html
+---
+

--- a/oneccl/api/function_ccl_8h_1aa890514a6e244e841dcb1f3c6c4a616f.html
+++ b/oneccl/api/function_ccl_8h_1aa890514a6e244e841dcb1f3c6c4a616f.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1aa890514a6e244e841dcb1f3c6c4a616f.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1aa890514a6e244e841dcb1f3c6c4a616f.html
+---
+

--- a/oneccl/api/function_ccl_8h_1aad4a37be50f4cdcf9c056dc48b18cf54.html
+++ b/oneccl/api/function_ccl_8h_1aad4a37be50f4cdcf9c056dc48b18cf54.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1aad4a37be50f4cdcf9c056dc48b18cf54.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1aad4a37be50f4cdcf9c056dc48b18cf54.html
+---
+

--- a/oneccl/api/function_ccl_8h_1ab87c372553134eb945fcbafd63aca374.html
+++ b/oneccl/api/function_ccl_8h_1ab87c372553134eb945fcbafd63aca374.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1ab87c372553134eb945fcbafd63aca374.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1ab87c372553134eb945fcbafd63aca374.html
+---
+

--- a/oneccl/api/function_ccl_8h_1abb843675ca240e8d1aa42d604537ca62.html
+++ b/oneccl/api/function_ccl_8h_1abb843675ca240e8d1aa42d604537ca62.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1abb843675ca240e8d1aa42d604537ca62.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1abb843675ca240e8d1aa42d604537ca62.html
+---
+

--- a/oneccl/api/function_ccl_8h_1ac5618870776b28aac8f1f9e84b178577.html
+++ b/oneccl/api/function_ccl_8h_1ac5618870776b28aac8f1f9e84b178577.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1ac5618870776b28aac8f1f9e84b178577.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1ac5618870776b28aac8f1f9e84b178577.html
+---
+

--- a/oneccl/api/function_ccl_8h_1ad8a13061b6dc0088712f2a23aa65d4cd.html
+++ b/oneccl/api/function_ccl_8h_1ad8a13061b6dc0088712f2a23aa65d4cd.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1ad8a13061b6dc0088712f2a23aa65d4cd.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1ad8a13061b6dc0088712f2a23aa65d4cd.html
+---
+

--- a/oneccl/api/function_ccl_8h_1afa5037ae8c31a0596d2fcb0c03b867e1.html
+++ b/oneccl/api/function_ccl_8h_1afa5037ae8c31a0596d2fcb0c03b867e1.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl_8h_1afa5037ae8c31a0596d2fcb0c03b867e1.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl_8h_1afa5037ae8c31a0596d2fcb0c03b867e1.html
+---
+

--- a/oneccl/api/function_ccl__type__traits_8hpp_1a00146b9b475d5c7c61eacca34f0edb6c.html
+++ b/oneccl/api/function_ccl__type__traits_8hpp_1a00146b9b475d5c7c61eacca34f0edb6c.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl__type__traits_8hpp_1a00146b9b475d5c7c61eacca34f0edb6c.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl__type__traits_8hpp_1a00146b9b475d5c7c61eacca34f0edb6c.html
+---
+

--- a/oneccl/api/function_ccl__type__traits_8hpp_1a150aaf3343efbab089e5dea87737f60d.html
+++ b/oneccl/api/function_ccl__type__traits_8hpp_1a150aaf3343efbab089e5dea87737f60d.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl__type__traits_8hpp_1a150aaf3343efbab089e5dea87737f60d.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl__type__traits_8hpp_1a150aaf3343efbab089e5dea87737f60d.html
+---
+

--- a/oneccl/api/function_ccl__type__traits_8hpp_1a433b9255dcb5482e42bbb60e9064a397.html
+++ b/oneccl/api/function_ccl__type__traits_8hpp_1a433b9255dcb5482e42bbb60e9064a397.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl__type__traits_8hpp_1a433b9255dcb5482e42bbb60e9064a397.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl__type__traits_8hpp_1a433b9255dcb5482e42bbb60e9064a397.html
+---
+

--- a/oneccl/api/function_ccl__type__traits_8hpp_1a9d8bc3d839013305bbcb51a78d95c049.html
+++ b/oneccl/api/function_ccl__type__traits_8hpp_1a9d8bc3d839013305bbcb51a78d95c049.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/function_ccl__type__traits_8hpp_1a9d8bc3d839013305bbcb51a78d95c049.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/function_ccl__type__traits_8hpp_1a9d8bc3d839013305bbcb51a78d95c049.html
+---
+

--- a/oneccl/api/library_root.html
+++ b/oneccl/api/library_root.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/library_root.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/library_root.html
+---
+

--- a/oneccl/api/namespace_ccl.html
+++ b/oneccl/api/namespace_ccl.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/namespace_ccl.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/namespace_ccl.html
+---
+

--- a/oneccl/api/program_listing_file_include_ccl.h.html
+++ b/oneccl/api/program_listing_file_include_ccl.h.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/program_listing_file_include_ccl.h.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/program_listing_file_include_ccl.h.html
+---
+

--- a/oneccl/api/program_listing_file_include_ccl.hpp.html
+++ b/oneccl/api/program_listing_file_include_ccl.hpp.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/program_listing_file_include_ccl.hpp.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/program_listing_file_include_ccl.hpp.html
+---
+

--- a/oneccl/api/program_listing_file_include_ccl_type_traits.hpp.html
+++ b/oneccl/api/program_listing_file_include_ccl_type_traits.hpp.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/program_listing_file_include_ccl_type_traits.hpp.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/program_listing_file_include_ccl_type_traits.hpp.html
+---
+

--- a/oneccl/api/program_listing_file_include_ccl_types.h.html
+++ b/oneccl/api/program_listing_file_include_ccl_types.h.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/program_listing_file_include_ccl_types.h.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/program_listing_file_include_ccl_types.h.html
+---
+

--- a/oneccl/api/program_listing_file_include_ccl_types.hpp.html
+++ b/oneccl/api/program_listing_file_include_ccl_types.hpp.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/program_listing_file_include_ccl_types.hpp.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/program_listing_file_include_ccl_types.hpp.html
+---
+

--- a/oneccl/api/structccl__coll__attr__t.html
+++ b/oneccl/api/structccl__coll__attr__t.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/structccl__coll__attr__t.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/structccl__coll__attr__t.html
+---
+

--- a/oneccl/api/structccl__comm__attr__t.html
+++ b/oneccl/api/structccl__comm__attr__t.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/structccl__comm__attr__t.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/structccl__comm__attr__t.html
+---
+

--- a/oneccl/api/structccl__fn__context__t.html
+++ b/oneccl/api/structccl__fn__context__t.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/structccl__fn__context__t.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/structccl__fn__context__t.html
+---
+

--- a/oneccl/api/structccl__version__t.html
+++ b/oneccl/api/structccl__version__t.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/structccl__version__t.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/structccl__version__t.html
+---
+

--- a/oneccl/api/typedef_ccl_8hpp_1afa826e3536369b356fcb6a1a4f737e45.html
+++ b/oneccl/api/typedef_ccl_8hpp_1afa826e3536369b356fcb6a1a4f737e45.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl_8hpp_1afa826e3536369b356fcb6a1a4f737e45.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl_8hpp_1afa826e3536369b356fcb6a1a4f737e45.html
+---
+

--- a/oneccl/api/typedef_ccl_8hpp_1afb67f3fd79049729ef6509f6e8e44efa.html
+++ b/oneccl/api/typedef_ccl_8hpp_1afb67f3fd79049729ef6509f6e8e44efa.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl_8hpp_1afb67f3fd79049729ef6509f6e8e44efa.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl_8hpp_1afb67f3fd79049729ef6509f6e8e44efa.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8h_1a0df469be505174d5656a3c5cba27ddd1.html
+++ b/oneccl/api/typedef_ccl__types_8h_1a0df469be505174d5656a3c5cba27ddd1.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8h_1a0df469be505174d5656a3c5cba27ddd1.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8h_1a0df469be505174d5656a3c5cba27ddd1.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8h_1a18fa4bbd5cc606204bdada4979625ff4.html
+++ b/oneccl/api/typedef_ccl__types_8h_1a18fa4bbd5cc606204bdada4979625ff4.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8h_1a18fa4bbd5cc606204bdada4979625ff4.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8h_1a18fa4bbd5cc606204bdada4979625ff4.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8h_1a29e394996eef8187e70ba379781a14f2.html
+++ b/oneccl/api/typedef_ccl__types_8h_1a29e394996eef8187e70ba379781a14f2.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8h_1a29e394996eef8187e70ba379781a14f2.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8h_1a29e394996eef8187e70ba379781a14f2.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8h_1a625e9080b37af8c23414ab4c877caf93.html
+++ b/oneccl/api/typedef_ccl__types_8h_1a625e9080b37af8c23414ab4c877caf93.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8h_1a625e9080b37af8c23414ab4c877caf93.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8h_1a625e9080b37af8c23414ab4c877caf93.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8h_1aa827bd4240d612fa112cc603dda7172f.html
+++ b/oneccl/api/typedef_ccl__types_8h_1aa827bd4240d612fa112cc603dda7172f.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8h_1aa827bd4240d612fa112cc603dda7172f.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8h_1aa827bd4240d612fa112cc603dda7172f.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8h_1ad984e26c3463804b916a8b05b779a34b.html
+++ b/oneccl/api/typedef_ccl__types_8h_1ad984e26c3463804b916a8b05b779a34b.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8h_1ad984e26c3463804b916a8b05b779a34b.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8h_1ad984e26c3463804b916a8b05b779a34b.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8h_1adad59e98682ba3a78148d8f9d6161ed9.html
+++ b/oneccl/api/typedef_ccl__types_8h_1adad59e98682ba3a78148d8f9d6161ed9.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8h_1adad59e98682ba3a78148d8f9d6161ed9.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8h_1adad59e98682ba3a78148d8f9d6161ed9.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8h_1ae4f1fe2e25f4a0189765458d8a83def5.html
+++ b/oneccl/api/typedef_ccl__types_8h_1ae4f1fe2e25f4a0189765458d8a83def5.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8h_1ae4f1fe2e25f4a0189765458d8a83def5.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8h_1ae4f1fe2e25f4a0189765458d8a83def5.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8hpp_1a692462538360ba9d937a661ac98329c3.html
+++ b/oneccl/api/typedef_ccl__types_8hpp_1a692462538360ba9d937a661ac98329c3.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8hpp_1a692462538360ba9d937a661ac98329c3.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8hpp_1a692462538360ba9d937a661ac98329c3.html
+---
+

--- a/oneccl/api/typedef_ccl__types_8hpp_1aac061de382f1663be34bfa9cb1a90ede.html
+++ b/oneccl/api/typedef_ccl__types_8hpp_1aac061de382f1663be34bfa9cb1a90ede.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/typedef_ccl__types_8hpp_1aac061de382f1663be34bfa9cb1a90ede.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/typedef_ccl__types_8hpp_1aac061de382f1663be34bfa9cb1a90ede.html
+---
+

--- a/oneccl/api/unabridged_api.html
+++ b/oneccl/api/unabridged_api.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/unabridged_api.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/unabridged_api.html
+---
+

--- a/oneccl/api/unabridged_orphan.html
+++ b/oneccl/api/unabridged_orphan.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api/unabridged_orphan.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api/unabridged_orphan.html
+---
+

--- a/oneccl/api_reference.html
+++ b/oneccl/api_reference.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/api_reference.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/api_reference.html
+---
+

--- a/oneccl/collective_algorithms_selection.html
+++ b/oneccl/collective_algorithms_selection.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/collective_algorithms_selection.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/collective_algorithms_selection.html
+---
+

--- a/oneccl/collectives_caching.html
+++ b/oneccl/collectives_caching.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/collectives_caching.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/collectives_caching.html
+---
+

--- a/oneccl/collectives_execution.html
+++ b/oneccl/collectives_execution.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/collectives_execution.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/collectives_execution.html
+---
+

--- a/oneccl/collectives_fusion.html
+++ b/oneccl/collectives_fusion.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/collectives_fusion.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/collectives_fusion.html
+---
+

--- a/oneccl/collectives_prioritization.html
+++ b/oneccl/collectives_prioritization.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/collectives_prioritization.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/collectives_prioritization.html
+---
+

--- a/oneccl/elasticity.html
+++ b/oneccl/elasticity.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/elasticity.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/elasticity.html
+---
+

--- a/oneccl/env_variables.html
+++ b/oneccl/env_variables.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/env_variables.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/env_variables.html
+---
+

--- a/oneccl/genindex.html
+++ b/oneccl/genindex.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/genindex.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/genindex.html
+---
+

--- a/oneccl/index.html
+++ b/oneccl/index.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/index.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/index.html
+---
+

--- a/oneccl/installation.html
+++ b/oneccl/installation.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/installation.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/installation.html
+---
+

--- a/oneccl/legal.html
+++ b/oneccl/legal.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/legal.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/legal.html
+---
+

--- a/oneccl/optimization_notice.html
+++ b/oneccl/optimization_notice.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/optimization_notice.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/optimization_notice.html
+---
+

--- a/oneccl/prerequisites.html
+++ b/oneccl/prerequisites.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/prerequisites.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/prerequisites.html
+---
+

--- a/oneccl/sample.html
+++ b/oneccl/sample.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/sample.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/sample.html
+---
+

--- a/oneccl/search.html
+++ b/oneccl/search.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/search.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/search.html
+---
+

--- a/oneccl/sparse_collectives.html
+++ b/oneccl/sparse_collectives.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/sparse_collectives.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/sparse_collectives.html
+---
+

--- a/oneccl/spec/ccl_datatypes.html
+++ b/oneccl/spec/ccl_datatypes.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/ccl_datatypes.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/ccl_datatypes.html
+---
+

--- a/oneccl/spec/collective_call_attributes.html
+++ b/oneccl/spec/collective_call_attributes.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/collective_call_attributes.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/collective_call_attributes.html
+---
+

--- a/oneccl/spec/collective_communication.html
+++ b/oneccl/spec/collective_communication.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/collective_communication.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/collective_communication.html
+---
+

--- a/oneccl/spec/communication_primitives.html
+++ b/oneccl/spec/communication_primitives.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/communication_primitives.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/communication_primitives.html
+---
+

--- a/oneccl/spec/completion.html
+++ b/oneccl/spec/completion.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/completion.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/completion.html
+---
+

--- a/oneccl/spec/cpu_support.html
+++ b/oneccl/spec/cpu_support.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/cpu_support.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/cpu_support.html
+---
+

--- a/oneccl/spec/error_handling.html
+++ b/oneccl/spec/error_handling.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/error_handling.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/error_handling.html
+---
+

--- a/oneccl/spec/generic_workflow.html
+++ b/oneccl/spec/generic_workflow.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/generic_workflow.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/generic_workflow.html
+---
+

--- a/oneccl/spec/gpu_support.html
+++ b/oneccl/spec/gpu_support.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/gpu_support.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/gpu_support.html
+---
+

--- a/oneccl/spec/main_objects.html
+++ b/oneccl/spec/main_objects.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/spec/main_objects.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/spec/main_objects.html
+---
+

--- a/oneccl/sys_requirements.html
+++ b/oneccl/sys_requirements.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/sys_requirements.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/sys_requirements.html
+---
+

--- a/oneccl/transport_selection.html
+++ b/oneccl/transport_selection.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/transport_selection.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/transport_selection.html
+---
+

--- a/oneccl/unordered_collectives.html
+++ b/oneccl/unordered_collectives.html
@@ -1,0 +1,6 @@
+---
+permalink: /oneccl/unordered_collectives.html
+redirect_to:
+  - https://oneapi-src.github.io/oneCCL/unordered_collectives.html
+---
+


### PR DESCRIPTION
oneCCL migrated to a new location some time ago, but redirects for docs were not enabled at that point

search results provide links to the old location, which leads to 404 error

![image](https://user-images.githubusercontent.com/17865025/77677239-795fe680-6fa0-11ea-854f-440f01052464.png)
